### PR TITLE
Fix lazy images missing var name

### DIFF
--- a/js/lazy-images.js
+++ b/js/lazy-images.js
@@ -30,7 +30,7 @@ novicell.lazyload = novicell.lazyload || function (e) {
     var preventLoad = target.classList.contains('lazyload-measure') || target.classList.contains('lazyload-bg'); 
     var setMeasuredUrl = target.classList.contains('lazyload-measure');
     var setSrcSet = target.hasAttribute('data-srcset') && target.hasAttribute('data-query-obj');
-    var srcSrc = target.hasAttribute('data-src') && target.hasAttribute('data-query-obj');
+    var setSrc = target.hasAttribute('data-src') && target.hasAttribute('data-query-obj');
 
     if(preventLoad) {
         e.preventDefault();


### PR DESCRIPTION
I think you forgot to change the name of "srcSrc" for "setSrc"
I suppose you want that name that is the one declared in the if
This change fixes the error "setSrc is not defined"