### PR TITLE
Change Array.map for Array.prototype.slice.call

### DIFF
--- a/js/lazy-images.js
+++ b/js/lazy-images.js
@@ -83,7 +83,7 @@ novicell.lazyload = novicell.lazyload || function (e) {
 */
 var checkImages = function() {
     if (window.innerWidth > lastRefreshWidth + refreshWidth || window.innerWidth < lastRefreshWidth - refreshWidth) {
-        var loadedElements = Array.from(document.body.querySelectorAll('.lazyloaded'));
+        var loadedElements = Array.prototype.slice.call(document.body.querySelectorAll('.lazyloaded'));
         if(loadedElements.length > 0) {
             loadedElements.map(function(el){
                 el.classList.remove('lazyloaded');


### PR DESCRIPTION
Ok, this is embarassing 😳 
When I changed this I was thinking that Array.from is fully supported, but again, is not supported on IE11: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
Array.prototype.map is fully supported indeed, but if the map breaks the JS in IE before is a little bit useless 😅 
So my proposal here is use "Array.prototype.slice.call" to create the array of the nodelist and then iterate with the map
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)

Here you have and example working: [https://jsfiddle.net/9otmh5by/](https://jsfiddle.net/9otmh5by/)