### PR TITLE
Removed the expand value of 1000

### DIFF
--- a/js/lazy-images.js
+++ b/js/lazy-images.js
@@ -14,8 +14,6 @@ var refreshWidth = 50;
 
 // Lazysizes config
 window.lazySizesConfig = window.lazySizesConfig || {};
-window.lazySizesConfig.expand = 1000;
-
 
 /*
 *   Lazyload


### PR DESCRIPTION
From reading in the docs https://github.com/aFarkas/lazysizes i think the best option is to leave the expand value to default and not set a value to start with as it calculates it depending on the viewport by default.